### PR TITLE
OpenAPI Generatorを導入し、API仕様書を作成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // OpenAPI Generator
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
     // Apache Commons Lang
     // 便利機能、ユーティリティ
     implementation 'org.apache.commons:commons-lang3:3.14.0'

--- a/src/main/java/raisetech/StudentManagement/Application.java
+++ b/src/main/java/raisetech/StudentManagement/Application.java
@@ -1,9 +1,12 @@
 package raisetech.StudentManagement;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.RestController;
 
+@OpenAPIDefinition(info = @Info(title = "受講生管理システム"))
 @SpringBootApplication
 @RestController
 public class Application {

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -1,5 +1,10 @@
 package raisetech.StudentManagement.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -12,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import raisetech.StudentManagement.controller.handler.ErrorResponse;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.exception.NotFoundException;
 import raisetech.StudentManagement.service.StudentService;
@@ -29,6 +35,7 @@ public class StudentController {
 
     /**
      * コンストラクタ
+     *
      * @param service 受講生サービス
      */
     @Autowired
@@ -39,8 +46,41 @@ public class StudentController {
     /**
      * 受講生詳細の一覧検索です。
      * 全件検索を行うので、条件指定は行わないものになります。
+     *
      * @return 受講生詳細一覧（全件）
      */
+    @Operation(
+            operationId = "getStudentList",
+            summary = "一覧検索",
+            tags = {"検索"},
+            description = "受講生詳細の一覧検索です。全件検索を行うので、条件指定は行わないものになります。",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "200(OK)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = StudentDetail.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "404(Not Found)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "500(Internal Server Error)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            }
+    )
     @GetMapping("/studentList")
     public List<StudentDetail> getStudentList() throws NotFoundException {
         return service.searchStudentList();
@@ -49,9 +89,42 @@ public class StudentController {
     /**
      * 受講生詳細の検索です。
      * IDに基づく任意の受講生の情報を取得します。
+     *
      * @param id 受講生ID
      * @return 受講生情報
      */
+    @Operation(
+            operationId = "getStudentList",
+            summary = "受講生詳細検索",
+            tags = {"検索"},
+            description = "受講生詳細の検索です。IDに基づく任意の受講生の情報を取得します。",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "200(OK)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = StudentDetail.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "404(Not Found)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "500(Internal Server Error)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            }
+    )
     @GetMapping("/student/{id}")
     public StudentDetail getStudent(@PathVariable @Size(min = 1, max = 3) @Pattern(regexp = "\\d+") String id) throws NotFoundException {
         return service.searchStudent(id);
@@ -59,9 +132,53 @@ public class StudentController {
 
     /**
      * 受講生詳細の登録を行います。
+     *
      * @param studentDetail 受講生詳細情報
      * @return 実行結果
      */
+    @Operation(
+            operationId = "registerStudent",
+            summary = "新規受講生登録",
+            tags = {"登録"},
+            description = "新規受講生の情報を登録します。\n受講生IDとコースIDは自動採番、論理削除はデフォルトfalse、受講開始日・終了日はタイムスタンプとなっているため、入力不要です。",
+
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = "{" +
+                                            "\"student\": {\"name\": \"佐藤太郎\", \"kana\": \"サトウタロウ\", \"nickname\": \"たろたん\", \"email\": \"taro@example.com\", \"address\": \"東京都,港区\", \"age\": 20, \"gender\": \"男\", \"remark\": \"特になし\"}, " +
+                                            "\"studentCourseList\": [{\"course\": \"サックスコース\"}]}"
+                            )
+                    )
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "200(OK)",
+                            content = @Content(
+                                    mediaType = "text/plain",
+                                    schema = @Schema(type = "String", example = "新規受講生の登録を行いました")
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "400(Bad Request)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "500(Internal Server Error)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            }
+    )
+
     @PostMapping("/registerStudent")
     public ResponseEntity<StudentDetail> registerStudent(@RequestBody @Valid StudentDetail studentDetail) {
         StudentDetail responseStudentDetail = service.registerStudent(studentDetail);
@@ -71,9 +188,61 @@ public class StudentController {
     /**
      * 受講生詳細の更新を行います。
      * キャンセルフラグの更新もここで行います（論理削除）。
+     *
      * @param studentDetail 受講生詳細
      * @return 実行結果
      */
+    @Operation(
+            operationId = "updateStudent",
+            summary = "受講生情報更新",
+            tags = {"更新/論理削除"},
+            description = "任意の既存受講生の情報を更新します。キャンセルフラグの更新もここで行います（論理削除）。",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            examples = @ExampleObject(
+                                    value = "{" +
+                                            "\"student\": {\"id\": \"1\", \"name\": \"佐藤太郎\", \"kana\": \"サトウタロウ\", \"nickname\": \"たろたん\", \"email\": \"taro@example.com\", \"address\": \"東京都,港区\", \"age\": 20, \"gender\": \"男\", \"remark\": \"特になし\", \"isDeleted\": false}, " +
+                                            "\"studentCourseList\": [{\"course\": \"サックスコース\"}]}"
+                            )
+                    )
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "200(OK)",
+                            content = @Content(
+                                    mediaType = "text/plain",
+                                    schema = @Schema(type = "String", example = "受講生情報の更新を行いました")
+                            )
+                    )
+                    ,
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "400(Bad Request)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "404(Not Found)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "500(Internal Server Error)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            }
+    )
+
     @PutMapping("/updateStudent")
     public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) throws NotFoundException {
         service.updateStudent(studentDetail);
@@ -82,11 +251,28 @@ public class StudentController {
 
     /**
      * 例外を発生させるメソッドです。
+     *
      * @return 実行結果
      * @throws Exception 例外
      */
+    @Operation(
+            operationId = "exception",
+            summary = "例外スロー",
+            tags = {"例外"},
+            description = "例外を発生させます",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "500(Internal Server Error)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            }
+    )
     @GetMapping("/exception")
     public String exception() throws Exception {
-       throw new Exception();
+        throw new Exception();
     }
 }

--- a/src/main/java/raisetech/StudentManagement/controller/handler/ErrorResponse.java
+++ b/src/main/java/raisetech/StudentManagement/controller/handler/ErrorResponse.java
@@ -1,0 +1,17 @@
+package raisetech.StudentManagement.controller.handler;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "例外発生時のレスポンス")
+@Setter
+@Getter
+public class ErrorResponse {
+
+    private String errorMessage;
+
+    public ErrorResponse() {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/raisetech/StudentManagement/controller/handler/ExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagement/controller/handler/ExceptionHandler.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.controller.handler;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import raisetech.StudentManagement.exception.NotFoundException;
 
+@Schema(description = "例外")
 @ControllerAdvice
 public class ExceptionHandler {
 
@@ -17,7 +19,9 @@ public class ExceptionHandler {
      */
     @org.springframework.web.bind.annotation.ExceptionHandler(NotFoundException.class)
     public ResponseEntity<String> handleNotFoundException(Exception ex){
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body("エラーメッセージ：\n" + ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setErrorMessage("エラーコード：\n404\n" + ex.getMessage() + "\n");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse.getErrorMessage());
     }
 
     /**
@@ -30,12 +34,15 @@ public class ExceptionHandler {
         StringBuilder errors = new StringBuilder();
 
         for (FieldError error : ex.getBindingResult().getFieldErrors()) {
-            errors.append("エラーメッセージ: ")
+            errors.append("エラーコード：\n400\nエラーメッセージ：\n")
                     .append(error.getDefaultMessage())
                     .append("\n");
         }
 
-        return new ResponseEntity<>(errors.toString(), HttpStatus.BAD_REQUEST);
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setErrorMessage(errors.toString());
+
+        return new ResponseEntity<>(errorResponse.getErrorMessage(), HttpStatus.BAD_REQUEST);
     }
 
     /**
@@ -45,6 +52,8 @@ public class ExceptionHandler {
      */
     @org.springframework.web.bind.annotation.ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleGeneralException(Exception ex) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("エラーメッセージ：\n" + ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setErrorMessage("エラーコード：\n500\n" + ex.getMessage() + "\n");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse.getErrorMessage());
     }
 }

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.data;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +12,7 @@ import lombok.Setter;
 /**
  * 受講生を扱うオブジェクト
  */
+@Schema(description = "受講生")
 @Getter
 @Setter
 public class Student {

--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -1,5 +1,7 @@
 package raisetech.StudentManagement.data;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -10,12 +12,15 @@ import java.time.LocalDateTime;
 /**
  * 受講生コース情報を扱うオブジェクト
  */
+@Schema(description = "受講生コース情報")
 @Getter
 @Setter
 public class StudentCourse {
 
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private String courseId;
 
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private String studentId;
 
     @NotBlank
@@ -23,8 +28,10 @@ public class StudentCourse {
             message = "コースは「ピアノコース」「ギターコース」「ドラムコース」「ヴァイオリンコース」「サックスコース」「ボーカルコース」のいずれかで選択してください")
     private String course;
 
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime startAt;
 
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime completeAt;
 
 }

--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import raisetech.StudentManagement.data.StudentCourse;
 
 import java.util.List;
 
+@Schema(description = "受講生詳細")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
第38回「ドキュメントの必要性と作り方」の課題を提出いたします。

OpenAPI Generatorを依存関係に追加し、API仕様書を作成しました。

API仕様書として、Swagger UIのスクリーンショットを添付いたします。
![localhost_8080_swagger-ui_index html (2)](https://github.com/user-attachments/assets/34128e69-c9b6-4f71-b237-ccbed90fb717)

ご査収のほど、よろしくお願いいたします。