### PR TITLE
Controller部分と入力チェックのテストを実装

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -126,7 +126,10 @@ public class StudentController {
             }
     )
     @GetMapping("/student/{id}")
-    public StudentDetail getStudent(@PathVariable @Size(min = 1, max = 3) @Pattern(regexp = "\\d+") String id) throws NotFoundException {
+    public StudentDetail getStudent(@PathVariable
+                                    @Size(min = 1, max = 3)
+                                    @Pattern(regexp = "\\d+", message = "IDは数字のみにする必要があります")
+                                    String id) throws NotFoundException {
         return service.searchStudent(id);
     }
 

--- a/src/main/java/raisetech/StudentManagement/controller/handler/ExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagement/controller/handler/ExceptionHandler.java
@@ -1,12 +1,14 @@
 package raisetech.StudentManagement.controller.handler;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import raisetech.StudentManagement.exception.NotFoundException;
+
+import java.util.stream.Collectors;
 
 @Schema(description = "例外")
 @ControllerAdvice
@@ -25,19 +27,33 @@ public class ExceptionHandler {
     }
 
     /**
+     * 受講生詳細検索で、リクエストのIDがバリデーションに失敗したとき場合の例外処理です。
+     * @param ex
+     * @return BAD_REQUEST
+     */
+    @org.springframework.web.bind.annotation.ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<String> handleConstraintViolation(ConstraintViolationException ex) {
+
+        String errors = ex.getConstraintViolations().stream()
+                .map(violation -> "エラーコード：400\nエラーメッセージ：\n" + violation.getMessage())
+                .collect(Collectors.joining("\n"));
+
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setErrorMessage(errors);
+
+        return new ResponseEntity<>(errorResponse.getErrorMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    /**
      * 受講生新規登録と受講生更新を実行したとき、バリデーションに失敗した場合の例外処理です。
      * @param ex
      * @return BAD_REQUEST
      */
     @org.springframework.web.bind.annotation.ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        StringBuilder errors = new StringBuilder();
-
-        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
-            errors.append("エラーコード：400\nエラーメッセージ：\n")
-                    .append(error.getDefaultMessage())
-                    .append("\n");
-        }
+        String errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> "エラーコード：400\nエラーメッセージ：\n" + error.getDefaultMessage())
+                .collect(Collectors.joining("\n"));
 
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setErrorMessage(errors.toString());

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -39,7 +39,7 @@ public class Student {
     private String address;
 
     @NotNull(message = "年齢が入力されていません")
-    private int age;
+    private Integer age;
 
     @NotBlank(message = "性別が入力されていません")
     @Pattern(regexp = "男|女|その他", message = "性別は「男」「女」「その他」のいずれかで選択してください")

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -1,0 +1,386 @@
+package raisetech.StudentManagement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import raisetech.StudentManagement.data.Student;
+import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.service.StudentService;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StudentController.class)
+class StudentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StudentService service;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void 正常系_受講生詳細の一覧検索が実行できて空のリストが返ってくること() throws Exception {
+        mockMvc.perform(get("/studentList"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(service, times(1)).searchStudentList();
+    }
+
+    @Test
+    void 正常系_受講生詳細の検索が実行できて空の受講生詳細が返ってくること() throws Exception {
+        String id = "999";
+        mockMvc.perform(get("/student/{id}", id))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(service, times(1)).searchStudent(id);
+    }
+
+    @Test
+    void 異常系_受講生詳細の検索でIDに数字以外が入力されたときに異常が発生すること() throws Exception {
+        String id = "テスト";
+        mockMvc.perform(get("/student/{id}", id))
+                .andDo(print())
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void 正常系_受講生詳細の登録が実行できること() throws Exception {
+
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こうじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+        student.setRemark("登録テストです");
+        StudentCourse studentCourse = new StudentCourse();
+        studentCourse.setStudentId(student.getId());
+        studentCourse.setCourse("ピアノコース");
+        List<StudentCourse> studentCourseList = List.of(studentCourse);
+        StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+
+        String request = objectMapper.writeValueAsString(studentDetail);
+
+        when(service.registerStudent(any(StudentDetail.class))).thenReturn(studentDetail);
+
+        mockMvc.perform(post("/registerStudent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(service, times(1)).registerStudent(any(StudentDetail.class));
+    }
+
+    @Test
+    void 正常系_受講生詳細の更新が実行できること() throws Exception {
+        Student student = new Student();
+        student.setId("999");
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こうじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+        student.setRemark("更新テストです");
+        student.setDeleted(true);
+        StudentCourse studentCourse = new StudentCourse();
+        studentCourse.setStudentId(student.getId());
+        studentCourse.setCourse("ピアノコース");
+        List<StudentCourse> studentCourseList = List.of(studentCourse);
+        StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+
+        String request = objectMapper.writeValueAsString(studentDetail);
+
+        when(service.registerStudent(any(StudentDetail.class))).thenReturn(studentDetail);
+
+
+        mockMvc.perform(put("/updateStudent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(student.getName() + "さんの情報を更新しました"));
+
+        verify(service, times(1)).updateStudent(any(StudentDetail.class));
+    }
+
+    @Test
+    void 異常系_受講生詳細の例外APIが実行できてステータスが500で返ってくること() throws Exception {
+        mockMvc.perform(get("/exception"))
+                .andDo(print())
+                .andExpect(status().is5xxServerError())
+                .andExpect(content().string("エラーコード：500\nエラーメッセージ：\nこのAPIは現在利用できません\n"));
+    }
+
+    @Test
+    void 正常系_入力チェック_受講生詳細の受講生で適切な値を入力したときに異常が発生しないこと() {
+        Student student = new Student();
+        student.setId("999");
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(0);
+    }
+
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生でIDに4文字以上の数字を用いたとき入力チェックに掛かること() {
+        Student student = new Student();
+        student.setId("99999");
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("IDは3桁までにする必要があります");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生でIDに数字以外を用いたとき入力チェックに掛かること() {
+        Student student = new Student();
+        student.setId("テスト");
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("IDは数字のみにする必要があります");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生で名前が空欄だったとき入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName(null);
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("名前が入力されていません");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生でフリガナが空欄だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana(null);
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("フリガナが入力されていません");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生でフリガナが全角カタカナ以外だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("えなみこうじ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message")
+                .containsOnly("フリガナは全角カタカナで入力してください");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生でニックネームが空欄だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname(null);
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("ニックネームが入力されていません");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生でメールアドレスが空欄だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail(null);
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("メールアドレスが入力されていません");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生でメールアドレスが不正な形式だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@koji@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("無効なメールアドレス形式です");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生で住所が空欄だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress(null);
+        student.setAge(36);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("住所が入力されていません");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生で年齢が空欄だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(null);
+        student.setGender("男");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("年齢が入力されていません");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生で性別が空欄だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender(null);
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message").containsOnly("性別が入力されていません");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細の受講生で性別が期待値以外だったときに入力チェックに掛かること() {
+        Student student = new Student();
+        student.setName("江並公史");
+        student.setKana("エナミコウジ");
+        student.setNickname("こーじ");
+        student.setEmail("test@example.com");
+        student.setAddress("奈良県,奈良市");
+        student.setAge(36);
+        student.setGender("男性");
+
+        Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message")
+                .containsOnly("性別は「男」「女」「その他」のいずれかで選択してください");
+    }
+
+    @Test
+    void 異常系_入力チェック_受講生詳細のコース情報でコース名が期待値以外だったときに入力チェックに掛かること() {
+        StudentCourse studentCourse = new StudentCourse();
+        studentCourse.setCourse("ピアノ");
+
+        Set<ConstraintViolation<StudentCourse>> violations = validator.validate(studentCourse);
+
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations).extracting("message")
+                .containsOnly("コースは「ピアノコース」「ギターコース」「ドラムコース」「ヴァイオリンコース」" +
+                              "「サックスコース」「ボーカルコース」のいずれかで選択してください");
+    }
+
+}

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -15,14 +15,12 @@ import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.service.StudentService;
 
-import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -68,34 +66,33 @@ class StudentControllerTest {
         String id = "テスト";
         mockMvc.perform(get("/student/{id}", id))
                 .andDo(print())
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isBadRequest());
     }
 
     @Test
-    void 正常系_受講生詳細の登録が実行できること() throws Exception {
-
-        Student student = new Student();
-        student.setName("江並公史");
-        student.setKana("エナミコウジ");
-        student.setNickname("こうじ");
-        student.setEmail("test@example.com");
-        student.setAddress("奈良県,奈良市");
-        student.setAge(36);
-        student.setGender("男");
-        student.setRemark("登録テストです");
-        StudentCourse studentCourse = new StudentCourse();
-        studentCourse.setStudentId(student.getId());
-        studentCourse.setCourse("ピアノコース");
-        List<StudentCourse> studentCourseList = List.of(studentCourse);
-        StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
-
-        String request = objectMapper.writeValueAsString(studentDetail);
-
-        when(service.registerStudent(any(StudentDetail.class))).thenReturn(studentDetail);
+    void 正常系_受講生詳細の登録が実行できて空で返ってくること() throws Exception {
 
         mockMvc.perform(post("/registerStudent")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(request))
+                        .content("""
+                                {
+                                    "student" : {
+                                        "name" : "江並公史",
+                                        "kana" : "エナミコウジ",
+                                        "nickname" : "こーじ",
+                                        "email" : "test@example.com",
+                                        "address" : "奈良県,奈良市",
+                                        "age" : 36,
+                                        "gender" : "男",
+                                        "remark" : "登録テストです"
+                                    },
+                                    "studentCourseList" : [
+                                        {
+                                            "course" : "ピアノコース"
+                                        }
+                                    ]
+                                }
+                                """))
                 .andDo(print())
                 .andExpect(status().isOk());
 
@@ -103,35 +100,38 @@ class StudentControllerTest {
     }
 
     @Test
-    void 正常系_受講生詳細の更新が実行できること() throws Exception {
-        Student student = new Student();
-        student.setId("999");
-        student.setName("江並公史");
-        student.setKana("エナミコウジ");
-        student.setNickname("こうじ");
-        student.setEmail("test@example.com");
-        student.setAddress("奈良県,奈良市");
-        student.setAge(36);
-        student.setGender("男");
-        student.setRemark("更新テストです");
-        student.setDeleted(true);
-        StudentCourse studentCourse = new StudentCourse();
-        studentCourse.setStudentId(student.getId());
-        studentCourse.setCourse("ピアノコース");
-        List<StudentCourse> studentCourseList = List.of(studentCourse);
-        StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
-
-        String request = objectMapper.writeValueAsString(studentDetail);
-
-        when(service.registerStudent(any(StudentDetail.class))).thenReturn(studentDetail);
-
+    void 正常系_受講生詳細の更新が実行できて更新完了メッセージが返ってくること() throws Exception {
 
         mockMvc.perform(put("/updateStudent")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(request))
+                        .content("""
+                                {
+                                    "student" : {
+                                        "id" : "999",
+                                        "name" : "江並公史",
+                                        "kana" : "エナミコウジ",
+                                        "nickname" : "こーじ",
+                                        "email" : "test@example.com",
+                                        "address" : "奈良県,奈良市",
+                                        "age" : 36,
+                                        "gender" : "男",
+                                        "remark" : "更新テストです",
+                                        "isDeleted" : true
+                                    },
+                                    "studentCourseList" : [
+                                        {
+                                            "courseId" : "99999",
+                                            "studentId" : "999",
+                                            "course" : "ピアノコース",
+                                            "startAt" : "2024-01-01 00:00:00",
+                                            "completeAt" : "2025-01-01 00:00:00"
+                                        }
+                                    ]
+                                }
+                                """))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().string(student.getName() + "さんの情報を更新しました"));
+                .andExpect(content().string("江並公史さんの情報を更新しました"));
 
         verify(service, times(1)).updateStudent(any(StudentDetail.class));
     }


### PR DESCRIPTION
## 第41回課題内容
・Controller部分の全メソッドのテストを実装
・Studentクラスの入力チェックのテストを実装
・StudentCourseクラスの入力チェックのテストを実装

## 確認していただきたい点
次の講義の冒頭を確認し、登録と更新のテストの書き方がずいぶん違ったので、わたしの書いたものはこれでよかったのか、アドバイスいただきたいです。該当の2箇所にコメントをつけております。

## 実装内容
StudentControllerTestクラスを作成し、合計20個のテストを実装しました。
内訳は、Controllerのテスト6個、Studentクラスの入力チェックテスト13個、StudentCourseクラスの入力チェックテスト1個です。

## 備考
Studentクラスの入力チェックテスト作成に伴って、年齢ageの型をintからIntegerに変更しました。
こちらも該当箇所にコメントをつけております。

## 実行結果
![image](https://github.com/user-attachments/assets/aa00b0d1-2cd2-4b4d-bc2d-a96601cd03d1)
