### PR TITLE
initStudentCourseの移動

### DIFF
--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -34,9 +34,7 @@ public class StudentCourse {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime completeAt;
 
-    public static StudentCourse initStudentCourse(StudentCourse studentCourse, String id) {
-        LocalDateTime now = LocalDateTime.now();
-
+    public static StudentCourse initStudentCourse(StudentCourse studentCourse, String id, LocalDateTime now) {
         studentCourse.setStudentId(id);
         studentCourse.setStartAt(now);
         studentCourse.setCompleteAt(now.plusYears(1));

--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -34,4 +34,12 @@ public class StudentCourse {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime completeAt;
 
+    public static StudentCourse initStudentCourse(StudentCourse studentCourse, String id) {
+        LocalDateTime now = LocalDateTime.now();
+
+        studentCourse.setStudentId(id);
+        studentCourse.setStartAt(now);
+        studentCourse.setCompleteAt(now.plusYears(1));
+        return studentCourse;
+    }
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -10,6 +10,7 @@ import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.exception.NotFoundException;
 import raisetech.StudentManagement.repository.StudentRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -75,7 +76,7 @@ public class StudentService {
 
         repository.registerStudent(student);
         studentDetail.getStudentCourseList().forEach(studentCourse -> {
-            StudentCourse.initStudentCourse(studentCourse, student.getId());
+            StudentCourse.initStudentCourse(studentCourse, student.getId(), LocalDateTime.now());
             repository.registerStudentCourse(studentCourse);
         });
         return studentDetail;

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -10,7 +10,6 @@ import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.exception.NotFoundException;
 import raisetech.StudentManagement.repository.StudentRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -39,7 +38,7 @@ public class StudentService {
         List<Student> studentList = repository.search();
         List<StudentCourse> studentCourseList = repository.searchStudentCourseList();
 
-        if (studentList.isEmpty()){
+        if (studentList.isEmpty()) {
             throw new NotFoundException("登録されている受講生はいません");
         }
         return converter.convertStudentDetails(studentList, studentCourseList);
@@ -76,24 +75,10 @@ public class StudentService {
 
         repository.registerStudent(student);
         studentDetail.getStudentCourseList().forEach(studentCourse -> {
-            initStudentCourse(studentCourse, student.getId());
+            StudentCourse.initStudentCourse(studentCourse, student.getId());
             repository.registerStudentCourse(studentCourse);
         });
         return studentDetail;
-    }
-
-    /**
-     * 受講生コース情報を登録する際の初期情報を設定する。
-     *
-     * @param studentCourse 受講生コース情報
-     * @param id            受講生ID
-     */
-     void initStudentCourse(StudentCourse studentCourse, String id) {
-        LocalDateTime now = LocalDateTime.now();
-
-        studentCourse.setStudentId(id);
-        studentCourse.setStartAt(now);
-        studentCourse.setCompleteAt(now.plusYears(1));
     }
 
     /**
@@ -107,7 +92,7 @@ public class StudentService {
 
         String id = studentDetail.getStudent().getId();
         Student student = repository.searchStudent(id);
-        if (student == null){
+        if (student == null) {
             throw new NotFoundException("ID " + id + " の学生は登録されていません");
         }
 

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -1,6 +1,5 @@
 package raisetech.StudentManagement.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -36,8 +35,6 @@ class StudentControllerTest {
 
     @MockBean
     private StudentService service;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 

--- a/src/test/java/raisetech/StudentManagement/data/StudentCourseTest.java
+++ b/src/test/java/raisetech/StudentManagement/data/StudentCourseTest.java
@@ -1,13 +1,11 @@
 package raisetech.StudentManagement.data;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
 import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@WebMvcTest(StudentCourse.class)
 class StudentCourseTest {
 
     @Test

--- a/src/test/java/raisetech/StudentManagement/data/StudentCourseTest.java
+++ b/src/test/java/raisetech/StudentManagement/data/StudentCourseTest.java
@@ -1,0 +1,26 @@
+package raisetech.StudentManagement.data;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WebMvcTest(StudentCourse.class)
+class StudentCourseTest {
+
+    @Test
+    void 正常系_受講生コース情報の初期値設定ができること() {
+        String id = "999";
+        StudentCourse studentCourse = new StudentCourse();
+
+        StudentCourse.initStudentCourse(studentCourse, id);
+
+        assertEquals(id, studentCourse.getStudentId());
+        assertEquals(LocalDateTime.now().getYear(), studentCourse.getStartAt().getYear());
+        assertEquals(LocalDateTime.now().getMonth(), studentCourse.getStartAt().getMonth());
+        assertEquals(LocalDateTime.now().getDayOfMonth(), studentCourse.getStartAt().getDayOfMonth());
+        assertEquals(studentCourse.getStartAt().plusYears(1), studentCourse.getCompleteAt());
+    }
+}

--- a/src/test/java/raisetech/StudentManagement/data/StudentCourseTest.java
+++ b/src/test/java/raisetech/StudentManagement/data/StudentCourseTest.java
@@ -12,13 +12,14 @@ class StudentCourseTest {
     void 正常系_受講生コース情報の初期値設定ができること() {
         String id = "999";
         StudentCourse studentCourse = new StudentCourse();
+        LocalDateTime now = LocalDateTime.now();
 
-        StudentCourse.initStudentCourse(studentCourse, id);
+        StudentCourse.initStudentCourse(studentCourse, id, now);
 
         assertEquals(id, studentCourse.getStudentId());
-        assertEquals(LocalDateTime.now().getYear(), studentCourse.getStartAt().getYear());
-        assertEquals(LocalDateTime.now().getMonth(), studentCourse.getStartAt().getMonth());
-        assertEquals(LocalDateTime.now().getDayOfMonth(), studentCourse.getStartAt().getDayOfMonth());
+        assertEquals(now.getYear(), studentCourse.getStartAt().getYear());
+        assertEquals(now.getMonth(), studentCourse.getStartAt().getMonth());
+        assertEquals(now.getDayOfMonth(), studentCourse.getStartAt().getDayOfMonth());
         assertEquals(studentCourse.getStartAt().plusYears(1), studentCourse.getCompleteAt());
     }
 }

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -13,7 +13,6 @@ import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.exception.NotFoundException;
 import raisetech.StudentManagement.repository.StudentRepository;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -92,7 +91,7 @@ class StudentServiceTest {
     }
 
     @Test
-    void 受講生登録_正常系_リポジトリとコース情報初期設定の処理が適切に呼び出せていること() {
+    void 受講生登録_正常系_リポジトリの処理が適切に呼び出せていること() {
         Student student = new Student();
         StudentCourse studentCourse = new StudentCourse();
         List<StudentCourse> studentCourseList = List.of(studentCourse);
@@ -102,20 +101,6 @@ class StudentServiceTest {
 
         verify(repository, times(1)).registerStudent(student);
         verify(repository, times(studentCourseList.size())).registerStudentCourse(studentCourse);
-    }
-
-    @Test
-    void 受講生コース情報登録_正常系_情報処理が適切に行われていること() {
-        Student student = new Student();
-        StudentCourse studentCourse = new StudentCourse();
-
-        sut.initStudentCourse(studentCourse, student.getId());
-
-        assertEquals(student.getId(), studentCourse.getStudentId());
-        assertEquals(LocalDateTime.now().getYear(), studentCourse.getStartAt().getYear());
-        assertEquals(LocalDateTime.now().getMonth(), studentCourse.getStartAt().getMonth());
-        assertEquals(LocalDateTime.now().getDayOfMonth(), studentCourse.getStartAt().getDayOfMonth());
-        assertEquals(studentCourse.getStartAt().plusYears(1), studentCourse.getCompleteAt());
     }
 
     @Test


### PR DESCRIPTION
## 実装内容
[こちらのPR](https://github.com/Karin99/StudentManagement/pull/13#discussion_r1839326637)  にてご指摘いただいた点を修正しました。
Serviceの登録処理で使用していた、StudentCourseの初期化メソッドinitStudentCourseを、ServiceクラスからStudentCourseクラスへ移動しました。
それに伴い、StudentCourseテストを作成し、initStudentCourseのテストへそちらへ移動しました。

## 実行結果
![image](https://github.com/user-attachments/assets/806ca5a6-2e02-4925-86a4-ac2b55958dc7)
