### PR TITLE
StudentConverterTestの実装

### DIFF
--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -6,12 +6,16 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
  * 受講生を扱うオブジェクト
  */
+@AllArgsConstructor
+@NoArgsConstructor
 @Schema(description = "受講生")
 @Getter
 @Setter

--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
@@ -12,6 +14,8 @@ import java.time.LocalDateTime;
 /**
  * 受講生コース情報を扱うオブジェクト
  */
+@AllArgsConstructor
+@NoArgsConstructor
 @Schema(description = "受講生コース情報")
 @Getter
 @Setter

--- a/src/test/java/raisetech/StudentManagement/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/converter/StudentConverterTest.java
@@ -6,6 +6,7 @@ import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.StudentDetail;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,20 +17,19 @@ class StudentConverterTest {
     private StudentConverter sut;
 
     @BeforeEach
-    void before(){
+    void before() {
         sut = new StudentConverter();
     }
 
     @Test
     void 正常系_受講生リストと受講生コース情報のリストを渡したときにIDに紐づいた受講生詳細のリストが返ってくること() {
-        String id = "999";
-
-        Student student = new Student();
-        student.setId(id);
+        Student student = new Student("999", "江並浩二", "エナミコウジ", "こーじ",
+                "koji@example.com", "奈良県", 36, "男", "特になし", false);
         List<Student> studentList = List.of(student);
 
-        StudentCourse studentCourse = new StudentCourse();
-        studentCourse.setStudentId(id);
+        LocalDateTime now = LocalDateTime.now();
+        StudentCourse studentCourse = new StudentCourse(
+                "999", "999", "ピアノコース", now, now.plusYears(1));
         List<StudentCourse> studentCourseList = List.of(studentCourse);
 
         List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
@@ -40,12 +40,13 @@ class StudentConverterTest {
 
     @Test
     void 正常系_受講生リストと受講生コース情報のリストを渡したときにIDに紐づかない受講生コース情報は除外されること() {
-        Student student = new Student();
-        student.setId("999");
+        Student student = new Student("999", "江並浩二", "エナミコウジ", "こーじ",
+                "koji@example.com", "奈良県", 36, "男", "特になし", false);
         List<Student> studentList = List.of(student);
 
-        StudentCourse studentCourse = new StudentCourse();
-        studentCourse.setStudentId("111");
+        LocalDateTime now = LocalDateTime.now();
+        StudentCourse studentCourse = new StudentCourse(
+                "999", "111", "ピアノコース", now, now.plusYears(1));
         List<StudentCourse> studentCourseList = List.of(studentCourse);
 
         List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);

--- a/src/test/java/raisetech/StudentManagement/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/converter/StudentConverterTest.java
@@ -1,0 +1,56 @@
+package raisetech.StudentManagement.controller.converter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import raisetech.StudentManagement.data.Student;
+import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.StudentDetail;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StudentConverterTest {
+
+    private StudentConverter sut;
+
+    @BeforeEach
+    void before(){
+        sut = new StudentConverter();
+    }
+
+    @Test
+    void 正常系_受講生リストと受講生コース情報のリストを渡したときにIDに紐づいた受講生詳細のリストが返ってくること() {
+        String id = "999";
+
+        Student student = new Student();
+        student.setId(id);
+        List<Student> studentList = List.of(student);
+
+        StudentCourse studentCourse = new StudentCourse();
+        studentCourse.setStudentId(id);
+        List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+        List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
+
+        assertEquals(student, actual.getFirst().getStudent());
+        assertEquals(studentCourseList, actual.getFirst().getStudentCourseList());
+    }
+
+    @Test
+    void 正常系_受講生リストと受講生コース情報のリストを渡したときにIDに紐づかない受講生コース情報は除外されること() {
+        Student student = new Student();
+        student.setId("999");
+        List<Student> studentList = List.of(student);
+
+        StudentCourse studentCourse = new StudentCourse();
+        studentCourse.setStudentId("111");
+        List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+        List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
+
+        assertThat(actual.getFirst().getStudent()).isEqualTo(student);
+        assertThat(actual.getFirst().getStudentCourseList()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 第42回課題内容
・StudentConverterのテストを実装する

## 実装内容
StudentConverterTestクラスを作成し、下記2つのテストを実装しました。
・受講生リストと受講生コース情報のリストを渡したときにIDに紐づいた受講生詳細のリストが返ってくること
・受講生リストと受講生コース情報のリストを渡したときにIDに紐づかない受講生コース情報は除外されること

## 確認していただきたい点
解説動画とは違う書き方になっていまして、"意味のあるテストになっているのか"を自分で判断するのが難しいので、ご確認いただきたいです。

## 実行結果
![image](https://github.com/user-attachments/assets/34ac2167-c88e-4781-ad36-bfcf5b413280)
